### PR TITLE
Updated base url and key

### DIFF
--- a/api.sh
+++ b/api.sh
@@ -2,9 +2,9 @@
 IFS=$'\n'
 
 slug=$1
-api_url="https://twist.moe/api/anime/${slug}/sources"
+api_url="https://api.twist.moe/api/anime/${slug}/sources"
 
-json=$(curl -s "${api_url}" -H 'x-access-token: 1rj2vRtegS8Y60B3w3qNZm5T2Q0TN2NR')
+json=$(curl -s "${api_url}" -H 'x-access-token: 0df14814b9e590a1f26d3071a4ed7974')
 rm .temp.txt
 for data in $(echo $json | python ../jsonP.py)
 do

--- a/decrypt.py
+++ b/decrypt.py
@@ -11,7 +11,8 @@ from Cryptodome.Cipher import AES
 from requests.utils import quote
 
 BLOCK_SIZE = 16
-KEY = b"LXgIVP&PorO68Rq7dTx8N^lP!Fa5sGJ^*XK"
+#KEY = b"LXgIVP&PorO68Rq7dTx8N^lP!Fa5sGJ^*XK"
+KEY = b"267041df55ca2b36f2e322d05ee2c9cf"
 
 # From stackoverflow https://stackoverflow.com/questions/36762098/how-to-decrypt-password-from-javascript-cryptojs-aes-encryptpassword-passphras
 def pad(data):

--- a/startp.sh
+++ b/startp.sh
@@ -55,7 +55,8 @@ slug=$di
 # IFS=$' '
 for i in $(bash ../api.sh "${slug}")
 do
-    j='https://twist.moe'
+    # j='https://twist.moe'
+    j='https://twistcdn.bunny.sh'
     j=$j$i
     echo $j
     echo $j >> $pw/$di/list.txt


### PR DESCRIPTION
The base URLs and key have changed, so I updated the scripts with the new URLs and keys.

Tested to work now.

```
$ ./startp.sh yuru-camp-2
URL: https://twist.moe/a/yuru-camp-2
Creating yuru-camp-2
making it https://twist.moe/a/yuru-camp-2/1
Fetching info...
https://twistcdn.bunny.sh/anime/yurucamps2/%5BSubsPlease%5D%20Yuru%20Camp%20S2%20-%2001v2%20(1080p)%20%5B8539B48E%5D.mp4
Creating yuru-camp-2/list.txt
copying download.sh to yuru-camp-2
Done
Check the Anime/yuru-camp-2 folder
Enjoy
Done
$ cd Anime/yuru-camp-2/
Anime/yuru-camp-2$ ./download.sh 
anime is yuru-camp-2
curl is installed: yes
Total no of episodes : 1
Enter 'a' for all episodes
start at:
a
downloading yuru-camp-2-1.mp4
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  374M  100  374M    0     0  4586k      0  0:01:23  0:01:23 --:--:-- 5124k
Anime/yuru-camp-2$ cd ..
```

Got the URLs and key by looking at commit `e097bff6a536f8347e9f8396e2d1fa9added53c7` of this [repo](https://github.com/Matheus-0/Anime-Twist).